### PR TITLE
Use KeyValueJoinCharacter property instead of "=" when constuct the string

### DIFF
--- a/Api/Helpers/QueryStringBuilder.cs
+++ b/Api/Helpers/QueryStringBuilder.cs
@@ -94,7 +94,7 @@ namespace KoenZomers.OneDrive.Api.Helpers
                         stringBuilder.Append(SeperatorCharacter);
                 }
                 stringBuilder.Append(keyValuePair.Key);
-                stringBuilder.Append('=');
+                stringBuilder.Append(KeyValueJoinCharacter);
                 stringBuilder.Append(Uri.EscapeDataString(keyValuePair.Value));
             }
             return stringBuilder.ToString();


### PR DESCRIPTION
Hi,
I suppose the presence of the property KeyValueJoinCharacter indicates the consumer of the class should be able to "format" the query with the character he defined (also is "=" in most case the default one to be used). Whatever for the moment, consumer is allow to set the property, but the class never uses it.